### PR TITLE
Add a run-component bin/script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ https://vast-woodland-9430.herokuapp.com/ | https://git.heroku.com/vast-woodland
 Git remote heroku added
 ```
 
-Of course, this doesn't solve the problem of setting up a proper
-config file, which is left as an exercise to the reader, for now.
-
 Now that you have an app, you can download and "install" a version
 by setting up `CONFLUENT_VERSION=1.0.1`, and deploying an app that
 makes use of confluent.
@@ -26,4 +23,31 @@ makes use of confluent.
 $ heroku config:set CONFLUENT_VERSION=1.0.1
 Setting config vars and restarting vast-woodland-9430... done, v3
 CONFLUENT_VERSION: 1.0.1
+```
+
+Setting `CONFLUENT_COMPONENT=(kafka-rest|schema-registry)` will also
+create a `bin/run-confluent` script, which will perform the following
+steps:
+
+* If you have an executable at the root of your app named
+  `properties-generate`, it will run it, with no arguments, and
+  redirect STDOUT to confluent.properties.
+
+* It will setup a trap to run `bin/$CONFLUENT_COMPONENT}-stop` on
+  SIGINT, or SIGTERM.
+
+* It will then substitute `%PORT%` for the value of the environment
+  variable `$PORT` (this enables static configuration).
+
+* It will then launch `bin/${CONFLUENT_COMPONENT}-start confluent.properties`
+
+This provides ultimate flexibility in generating your properties file
+from the heroku config, or through a static config file which is part
+of your app.
+
+## Your app's Procfile
+
+```bash
+$ cat Procfile
+web: bin/run-component
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -25,3 +25,26 @@ fi
 cp -a confluent-${CONFLUENT_VERSION}/* $BUILD_DIR/
 
 echo "Copied Confluent ${CONFLUENT_VERSION} successfully" | indent
+
+CONFLUENT_COMPONENT=$(cat ${ENV_DIR}/CONFLUENT_COMPONENT)
+
+if [[ -z "${CONFLUENT_COMPONENT}" ]]; then
+    echo "CONFLUENT_COMPONENT was not set, so not creating run-confluent script" | indent
+    exit 0
+fi
+
+cat > bin/run-confluent <<EOF
+#!/usr/bin/env bash
+
+if [ -x "./properties-generate" ]; then
+    ./properties-generate > confluent.properties
+fi
+
+trap "bin/${CONFLUENT_COMPONENT}-stop" SIGINT SIGTERM
+
+bin/${CONFLUENT_COMPONENT}-start confluent.properties
+EOF
+
+chmod a+x bin/run-confluent
+
+exit 0

--- a/bin/compile
+++ b/bin/compile
@@ -40,6 +40,8 @@ if [ -x "./properties-generate" ]; then
     ./properties-generate > confluent.properties
 fi
 
+sed -i -e "s/%PORT%/\${PORT}/g" confluent.properties
+
 trap "bin/${CONFLUENT_COMPONENT}-stop" SIGINT SIGTERM
 
 bin/${CONFLUENT_COMPONENT}-start confluent.properties


### PR DESCRIPTION
- If $CONFLUENT_COMPONENT is specified, generates a run script for Procfile
- This script runs properties-generate to enable config generation and sets
  up a trap to run the `-stop` command for the component.
- Does substitution of %PORT% on the generated / static properties file
  for web process port binding.

cc/ @cyx 
