### PR TITLE
Adds ability to override ARCHIVE_URL with newer version of confluent stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ of your app.
 
 ```bash
 $ cat Procfile
-web: bin/run-component
+web: bin/run-confluent
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -19,6 +19,7 @@ curl --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --st
 install_java_with_overlay ${BUILD_DIR}
 
 CONFLUENT_VERSION=$(cat ${ENV_DIR}/CONFLUENT_VERSION)
+ARCHIVE_URL_OVERRIDE=$(cat ${ENV_DIR}/ARCHIVE_URL_OVERRIDE)
 
 if [[ -z "${CONFLUENT_VERSION}" ]]; then
     echo "CONFLUENT_VERSION was not set. Aborting" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ if [[ -z "${CONFLUENT_VERSION}" ]]; then
     exit 1
 fi
 
-ARCHIVE_URL= ${ARCHIVE_URL_OVERRIDE:-http://packages.confluent.io/archive/1.0/confluent-${CONFLUENT_VERSION}-2.10.4.tar.gz}
+ARCHIVE_URL=${ARCHIVE_URL_OVERRIDE:-http://packages.confluent.io/archive/1.0/confluent-${CONFLUENT_VERSION}-2.10.4.tar.gz}
 wget -qO - $ARCHIVE_URL | tar -zxf -
 if ! [ $? ]; then
     echo "FAILED to obtain confluent distribution" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ if [[ -z "${CONFLUENT_VERSION}" ]]; then
     exit 1
 fi
 
-ARCHIVE_URL=http://packages.confluent.io/archive/1.0/confluent-${CONFLUENT_VERSION}-2.10.4.tar.gz
+ARCHIVE_URL= ${ARCHIVE_URL_OVERRIDE:-http://packages.confluent.io/archive/1.0/confluent-${CONFLUENT_VERSION}-2.10.4.tar.gz}
 wget -qO - $ARCHIVE_URL | tar -zxf -
 if ! [ $? ]; then
     echo "FAILED to obtain confluent distribution" | indent


### PR DESCRIPTION
Currently the buildpack won't accept version 2.x of the confluent stack due to the url being in the incorrect format. This PR will allow an arbitrary url to be provided to download the confluent stack.
