### PR TITLE
Download JVM Common from buildpack-registry instead of codon-buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,7 +9,7 @@ CACHE_DIR=$2
 ENV_DIR=$3
 
 # download the buildpack
-JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/jvm-common.tgz}
+JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/jvm.tgz}
 mkdir -p /tmp/jvm-common
 curl --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
 . /tmp/jvm-common/bin/util


### PR DESCRIPTION
The `codon-buildpacks` S3 bucket has been deprecated for many years, having been replaced by the buildpack registry shorthand aliases, which map to the `buildpack-registry` S3 bucket instead.

New buildpack releases are currently backported to the legacy `codon-buildpacks` bucket from `buildpack-registry` by a sync job (so this PR has no change on functionality), however that job will be sunset soon, causing `codon-buildpacks` to become stale.

GUS-W-10034067.